### PR TITLE
Dataset Optimizations

### DIFF
--- a/auramask/callbacks/callbacks.py
+++ b/auramask/callbacks/callbacks.py
@@ -60,7 +60,7 @@ class AuramaskCallback(WandbEvalCallback):
             data_table_columns=data_table_columns, pred_table_columns=pred_table_columns
         )
         if backend.backend() == "torch":
-            self.x = validation_data[:num_samples].detach().cpu()
+            self.x = validation_data[:num_samples]
         else:
             self.x = validation_data[:num_samples]
         self.log_freq = log_freq

--- a/auramask/models/auramask.py
+++ b/auramask/models/auramask.py
@@ -154,7 +154,8 @@ class AuraMask(Model):
         import torch
 
         X, y = data  # X is input image data, y is target image
-
+        X = ops.convert_to_tensor(X)
+        y = ops.convert_to_tensor(y)
         self.zero_grad()
 
         y_pred = self(X, training=True)
@@ -184,6 +185,9 @@ class AuraMask(Model):
         import torch
 
         X, y = data  # X is input image data, y is target image
+
+        X = ops.convert_to_tensor(X)
+        y = ops.convert_to_tensor(y)
 
         with torch.no_grad():
             y_pred = self(X, training=False)

--- a/auramask/utils/datasets.py
+++ b/auramask/utils/datasets.py
@@ -47,7 +47,7 @@ class DatasetEnum(Enum):
                 batched=True,
                 batch_size=batch,
                 num_proc=cpu_count(),
-            ).select_columns(self.value[-1] + ["target"])
+            )
         else:
             ds = ds.map(
                 lambda x: self.data_collater(x, collater_args),
@@ -55,7 +55,13 @@ class DatasetEnum(Enum):
                 batch_size=batch,
                 num_proc=cpu_count(),
                 input_columns=self.value[-1],
-            ).select_columns(self.value[-1])
+            )
+
+        if "target" in ds.column_names:
+            ds = ds.select_columns(self.value[-1] + ["target"])
+        else:
+            ds = ds.select_columns(self.value[-1])
+
         return ds
 
     class GeomConfig(TypedDict):

--- a/auramask/utils/datasets.py
+++ b/auramask/utils/datasets.py
@@ -224,6 +224,7 @@ class DatasetEnum(Enum):
             batch,
             shuffle=True,
             drop_last=True,
+            persistent_workers=True,
             collate_fn=lambda x: (
                 np.stack([im["image"] for im in x]),
                 np.stack([tar["target"] for tar in x]),
@@ -263,6 +264,7 @@ class DatasetEnum(Enum):
             test_ds,
             batch,
             shuffle=False,
+            persistent_workers=True,
             collate_fn=lambda x: (
                 np.stack([im["image"] for im in x]),
                 np.stack([tar["target"] for tar in x]),

--- a/auramask/utils/datasets.py
+++ b/auramask/utils/datasets.py
@@ -164,6 +164,18 @@ class DatasetEnum(Enum):
             ds = load_from_disk(cache_dir)
         else:
             ds = self.fetch_dataset()
+            if not prefilter:
+
+                def prefilter(features: list[PIL.Image.Image]):
+                    batch = {}
+                    batch["image"] = [
+                        PIL.ImageOps.autocontrast(
+                            PIL.ImageOps.equalize(f), preserve_tone=True
+                        )
+                        for f in features
+                    ]
+                    return batch
+
             ds = self.preprocess_dataset(
                 ds, batch, {"w": dim[0], "h": dim[1]}, prefilter
             )

--- a/auramask/utils/datasets.py
+++ b/auramask/utils/datasets.py
@@ -225,8 +225,8 @@ class DatasetEnum(Enum):
             shuffle=True,
             drop_last=True,
             collate_fn=augmenter,
-            prefetch_factor=4,
-            num_workers=2,
+            prefetch_factor=16,
+            num_workers=(cpu_count() - 8) if cpu_count() > 8 else 4,
             pin_memory=True,
         )
 
@@ -248,6 +248,7 @@ class DatasetEnum(Enum):
             shuffle=False,
             collate_fn=v_transform,
             num_workers=2,
+            prefetch_factor=8,
             pin_memory=True,
         )
 

--- a/auramask/utils/insta_filter.py
+++ b/auramask/utils/insta_filter.py
@@ -1,5 +1,5 @@
 from enum import Enum
-import pilgram
+import pilgram2 as pilgram
 from PIL.Image import Image
 from PIL.ImageOps import equalize, autocontrast
 

--- a/dataset-process.py
+++ b/dataset-process.py
@@ -97,10 +97,10 @@ def main():
     insta: InstaFilterEnum = hparams["instagram_filter"]
 
     ds.generate_ds(
-        insta.name,
+        insta.name if insta else "default",
         hparams["input"],
         batch=hparams["batch"],
-        prefilter=insta.filter_transform,
+        prefilter=insta.filter_transform if insta else None,
     )
 
 

--- a/dataset-process.py
+++ b/dataset-process.py
@@ -1,0 +1,108 @@
+# ruff: noqa: E402
+import argparse
+import enum
+import os
+from pathlib import Path
+
+os.environ["KERAS_BACKEND"] = "torch"
+
+import keras
+from auramask.utils.insta_filter import InstaFilterEnum
+from auramask.utils.datasets import DatasetEnum
+
+# Global hparams object
+hparams: dict = {}
+# Normalize network to use channels last ordering
+keras.backend.set_image_data_format("channels_last")
+
+
+# Path checking and creation if appropriate
+def dir_path(path):
+    if path:
+        path = Path(path)
+        try:
+            if not path.parent.parent.exists():
+                raise FileNotFoundError()
+            path.mkdir(parents=True, exist_ok=True)
+            return str(path.absolute())
+        except FileNotFoundError:
+            raise argparse.ArgumentTypeError(
+                f"The directory {path} cannot have more than 2 missing parents."
+            )
+        except FileExistsError:
+            raise argparse.ArgumentTypeError(f"The directory {path} exists as a file")
+    return
+
+
+# Action for enumeration input
+class EnumAction(argparse.Action):
+    """Action for an enumeration input, maps enumeration type to choices"""
+
+    def __init__(self, **kwargs):
+        # Pop off the type value
+        enum_type = kwargs.pop("type", None)
+
+        # Ensure an Enum subclass is provided
+        if enum_type is None:
+            raise ValueError("type must be assigned an Enum when using EnumAction")
+        if not issubclass(enum_type, enum.Enum):
+            raise TypeError("type must be an Enum when using EnumAction")
+
+        # Generate choices from the Enum
+        kwargs.setdefault("choices", tuple(e.name.lower() for e in enum_type))
+
+        super(EnumAction, self).__init__(**kwargs)
+
+        self._enum = enum_type
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # Convert value back into an Enum
+        if isinstance(values, str):
+            value = self._enum[values.upper()]
+        elif isinstance(values, list):
+            value = [self._enum[x.upper()] for x in values]
+        setattr(namespace, self.dest, value)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Dataset Preprocessing",
+        description="A script to generate a preprocessed cached dataset for use by the auramask training script",
+    )
+    parser.add_argument("-B", "--batch-size", dest="batch", type=int, default=32)
+    parser.add_argument(
+        "-D",
+        "--dataset",
+        default="lfw",
+        type=DatasetEnum,
+        action=EnumAction,
+        required=True,
+    )
+    parser.add_argument(
+        "--instagram-filter", type=InstaFilterEnum, action=EnumAction, required=False
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    hparams["input"] = (256, 256)
+    hparams.update(parse_args().__dict__)
+
+    # Load the dataset
+    ds: DatasetEnum = hparams["dataset"]
+
+    insta: InstaFilterEnum = hparams["instagram_filter"]
+
+    ds.generate_ds(
+        insta.name,
+        hparams["input"],
+        batch=hparams["batch"],
+        prefilter=insta.filter_transform,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ wandb
 torch
 torchvision
 lpips
-pilgram
+pilgram2
 albumentations
 ruff
 pre-commit

--- a/train.py
+++ b/train.py
@@ -227,14 +227,14 @@ def load_data():
     if test_size > 1.0:
         test_size = int(test_size)
 
-    insta = hparams["instagram_filter"]
-    t_ds, v_ds = ds.load_data(
-        train_size,
-        test_size,
+    insta: InstaFilterEnum = hparams["instagram_filter"]
+    data = ds.generate_ds(
+        insta.name,
         hparams["input"],
         hparams["batch"],
         insta.filter_transform if insta else None,
     )
+    t_ds, v_ds = ds.get_loaders(data, train_size, test_size, hparams["batch"])
 
     # from keras import preprocessing
 

--- a/train.py
+++ b/train.py
@@ -229,7 +229,7 @@ def load_data():
 
     insta: InstaFilterEnum = hparams["instagram_filter"]
     data = ds.generate_ds(
-        insta.name,
+        insta.name if insta else "default",
         hparams["input"],
         hparams["batch"],
         insta.filter_transform if insta else None,

--- a/train.py
+++ b/train.py
@@ -47,7 +47,9 @@ from keras import optimizers as opts, losses as ls, activations, ops, utils
 
 # Global hparams object
 hparams: dict = {}
-# keras.config.disable_traceback_filtering()
+keras.config.disable_traceback_filtering()
+# Normalize network to use channels last ordering
+keras.backend.set_image_data_format("channels_last")
 
 
 # Path checking and creation if appropriate
@@ -179,8 +181,8 @@ def parse_args():
         "--log", default=True, type=bool, action=argparse.BooleanOptionalAction
     )
     parser.add_argument("--log-dir", default=None, type=dir_path)
-    parser.add_argument("--training", type=str, required=True)
-    parser.add_argument("--validation", type=str, required=True)
+    parser.add_argument("--training", type=float, required=True)
+    parser.add_argument("--testing", type=float, required=True)
     parser.add_argument(
         "--eager", default=False, type=bool, action=argparse.BooleanOptionalAction
     )
@@ -217,118 +219,36 @@ def parse_args():
 
 def load_data():
     ds: DatasetEnum = hparams["dataset"]
-    t_ds, v_ds = ds.fetch_dataset(hparams["training"], hparams["validation"])
+    train_size, test_size = hparams["training"], hparams["testing"]
 
-    w, h = hparams["input"]
+    # In the case that a number of samples is passed in instead of a percentage of the test split
+    if train_size > 1.0:
+        train_size = int(train_size)
+    if test_size > 1.0:
+        test_size = int(test_size)
 
-    augmenters = ds.get_augmenters(
-        {"augs_per_image": 1, "rate": 0.5},
-        {"augs_per_image": 1, "rate": 0.2, "magnitude": 0.5},
+    insta = hparams["instagram_filter"]
+    t_ds, v_ds = ds.load_data(
+        train_size,
+        test_size,
+        hparams["input"],
+        hparams["batch"],
+        insta.filter_transform if insta else None,
     )
-
-    if keras.backend.backend() == "tensorflow":
-        keras.backend.set_image_data_format("channels_last")
-        t_ds = (
-            t_ds.to_tf_dataset(
-                columns=ds.value[2],
-                batch_size=hparams["batch"],
-                collate_fn=ds.data_collater,
-                collate_fn_args={"args": {"w": w, "h": h}},
-                prefetch=False,
-                shuffle=True,
-                drop_remainder=True,
-            )
-            .map(
-                lambda x: ds.data_augmenter(x, augmenters["geom"], augmenters["aug"]),
-                num_parallel_calls=-1,
-            )
-            .repeat()
-            .prefetch(-1)
-        )
-
-        v_ds = (
-            v_ds.to_tf_dataset(
-                columns=ds.value[2],
-                batch_size=hparams["batch"],
-                collate_fn=ds.data_collater,
-                collate_fn_args={"args": {"w": w, "h": h}},
-                prefetch=True,
-                drop_remainder=True,
-            )
-            .cache()
-            .prefetch(-1)
-        )
-
-    elif keras.backend.backend() == "torch":
-        keras.backend.set_image_data_format("channels_last")
-        insta = hparams["instagram_filter"]
-        from torch.utils.data import DataLoader
-
-        # This transform collates the data, converting all features into tensors, scaling to 0-1, resizing, and cropping
-        # Then it augments the data according to the random geometric and pixel-level augmentations set in preprocessing
-        # Finally, the embeddings of the unaltered image is pre-computed for each of the models in F
-        def transform(example):
-            example = ds.data_collater(example, {"w": w, "h": h})
-            return ds.data_augmenter(example, augmenters["geom"], augmenters["aug"])
-
-        if insta:
-            t_ds = t_ds.map(
-                lambda x: insta.filter_transform(x),
-                input_columns=ds.value[-1][-1],
-                load_from_cache_file=False,
-                batched=True,
-                batch_size=32,
-                num_proc=os.cpu_count(),
-            ).select_columns(ds.value[-1] + ["target"])
-        else:
-            t_ds = t_ds.select_columns(ds.value[-1])
-        t_ds = DataLoader(
-            t_ds,
-            int(hparams["batch"]),
-            shuffle=True,
-            drop_last=True,
-            collate_fn=transform,
-        )
-
-        def v_transform(example):
-            example = ds.data_collater(example, {"w": w, "h": h})
-            x = ops.convert_to_tensor(example[ds.value[-1][0]])
-            if len(ds.value[-1]) > 1:
-                y = ops.convert_to_tensor(example[ds.value[-1][1]])
-            elif "target" in example.keys():
-                y = ops.convert_to_tensor(example["target"])
-            else:
-                y = ops.copy(x)
-            return (x, y)
-
-        if insta:
-            v_ds = v_ds.map(
-                lambda x: insta.filter_transform(x),
-                input_columns=ds.value[-1][-1],
-                load_from_cache_file=False,
-                batched=True,
-                batch_size=32,
-                num_proc=os.cpu_count(),
-            )
-        else:
-            v_ds = v_ds.select_columns(ds.value[-1])
-        v_ds = DataLoader(
-            v_ds, int(hparams["batch"]), shuffle=False, collate_fn=v_transform
-        )
 
     # from keras import preprocessing
 
     # for example in t_ds:
-    #     # print(ops.max(example[0]), ops.min(example[0]))
-    #     # print(ops.max(example[1]), ops.min(example[1]))
+    #     print(ops.max(example[0]), ops.min(example[0]))
+    #     print(ops.max(example[1]), ops.min(example[1]))
     #     ex = ops.convert_to_numpy(example[0][0])
     #     ey = ops.convert_to_numpy(example[1][0])
     #     preprocessing.image.array_to_img(ex).save('train_in.png')
     #     preprocessing.image.array_to_img(ey).save('train_targ.png')
     #     break
     # for example in v_ds:
-    #     # print(ops.max(example[0]), ops.min(example[0]))
-    #     # print(ops.max(example[1]), ops.min(example[1]))
+    #     print(ops.max(example[0]), ops.min(example[0]))
+    #     print(ops.max(example[1]), ops.min(example[1]))
     #     ex = ops.convert_to_numpy(example[0][0])
     #     ey = ops.convert_to_numpy(example[1][0])
     #     preprocessing.image.array_to_img(ex).save('val_in.png')

--- a/train.py
+++ b/train.py
@@ -239,6 +239,7 @@ def load_data():
     # from keras import preprocessing
 
     # for example in t_ds:
+    #     print(example[0])
     #     print(ops.max(example[0]), ops.min(example[0]))
     #     print(ops.max(example[1]), ops.min(example[1]))
     #     ex = ops.convert_to_numpy(example[0][0])
@@ -247,6 +248,7 @@ def load_data():
     #     preprocessing.image.array_to_img(ey).save('train_targ.png')
     #     break
     # for example in v_ds:
+    #     print(example[0])
     #     print(ops.max(example[0]), ops.min(example[0]))
     #     print(ops.max(example[1]), ops.min(example[1]))
     #     ex = ops.convert_to_numpy(example[0][0])


### PR DESCRIPTION
# Changes
- Precompute instagram filters on given dataset with the intervening dataset saved to huggingface cache
- Change the train-test split computation from `--validation` and `--training` with string inputs to a scheme that takes in either integers indicating the number of samples or a float between 0 and 1 indicating the percentage of the training dataset to split on.
- Change `--validation` argument to `--testing`
- Refactor to allow for multiple workers to be assigned to DataLoader and use "set_transform" method of huggingface datasets for improved performance.